### PR TITLE
Fix video layout and remove conflict leftovers

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2,11 +2,13 @@ body {
   margin: 0;
   padding: 0;
   background-color: #000;
-  color: #fff;  font-family: Arial, sans-serif;
-  height: 100vh;
+  color: #fff;
+  font-family: Arial, sans-serif;
+  min-height: 100vh;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
+  justify-content: flex-start;
 }
 
 main {
@@ -66,34 +68,12 @@ main {
   justify-content: center;
   align-items: center;
   gap: 6px;
-  HEAD
-  margin-bottom: 12px;
-
-  margin-top: 12px;
-  master
+  margin: 12px 0;
   text-align: center;
   width: 100%;
   font-size: 14px;
 }
 
-
-.video-wrapper {
-  padding: 10px;
-  border: 2px solid #ff0000;
-  box-shadow: 0 0 15px #ff0000;
-  border-radius: 8px;
-}
-
-
-.sound-icon {
-  width: 20px;
-  height: 20px;
-margin-bottom: 12px;
-margin-top: 12px;
-text-align: center;
-width: 100%;
-font-size: 14px;
-}
 
 .video-wrapper {
   padding: 10px;

--- a/components/video.html
+++ b/components/video.html
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <div class="sound-alert">
   <img class="sound-icon" src="https://img.icons8.com/ios-filled/20/ffffff/speaker.png" alt="Som Ligado" />
   <span>Por favor, certifique-se de que o som esteja ligado.</span>
@@ -8,15 +7,10 @@
     <img id="thumb_6842141d891666ff59083fee" src="https://images.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/thumbnail.jpg" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; display: block;" alt="thumbnail" />
     <div id="backdrop_6842141d891666ff59083fee" style="-webkit-backdrop-filter: blur(5px); backdrop-filter: blur(5px); position: absolute; top: 0; height: 100%; width: 100%;"></div>
   </div>
-
   <script type="text/javascript" id="scr_6842141d891666ff59083fee">
     var s = document.createElement('script');
     s.src = 'https://scripts.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/player.js';
     s.async = true;
     document.head.appendChild(s);
   </script>
-  <div class="sound-alert">
-    <img class="sound-icon" src="https://img.icons8.com/ios-filled/20/ffffff/speaker.png" alt="Som Ligado" />
-    <span>Por favor, certifique-se de que o som esteja ligado.</span>
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- clean up merge conflict text from video component and CSS
- ensure page layout stacks vertically
- place sound alert above red video box
- keep CTA button centered below the video

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843911d5ab4832786de0b82e79a5661