### PR TITLE
Adjust video and CTA layout

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -6,12 +6,19 @@ async function loadComponent(id, path) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   await loadComponent('header', './components/header.html');
-  await loadComponent('main', './components/video.html');
+
+  const mainEl = document.getElementById('main');
+  const videoRes = await fetch('./components/video.html');
+  mainEl.innerHTML = await videoRes.text();
   const playerScript = document.createElement('script');
-  playerScript.src = 'https://scripts.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/player.js';
+  playerScript.src =
+    'https://scripts.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/player.js';
   playerScript.async = true;
   document.head.appendChild(playerScript);
-  await loadComponent('cta', './components/cta.html');
+
+  const ctaRes = await fetch('./components/cta.html');
+  mainEl.insertAdjacentHTML('beforeend', await ctaRes.text());
+
   await loadComponent('footer', './components/footer.html');
 
   setTimeout(() => {

--- a/assets/style.css
+++ b/assets/style.css
@@ -74,12 +74,22 @@ main {
   font-size: 14px;
 }
 
+.video-container {
+  width: 100%;
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 
 .video-wrapper {
-  padding: 10px;
+  width: 100%;
+  padding: 0;
   border: 2px solid #ff0000;
   box-shadow: 0 0 15px #ff0000;
   border-radius: 8px;
+  overflow: hidden;
 }
 
 .sound-icon {

--- a/components/video.html
+++ b/components/video.html
@@ -1,16 +1,18 @@
-<div class="sound-alert">
-  <img class="sound-icon" src="https://img.icons8.com/ios-filled/20/ffffff/speaker.png" alt="Som Ligado" />
-  <span>Por favor, certifique-se de que o som esteja ligado.</span>
-</div>
-<div class="video-wrapper">
-  <div id="vid_6842141d891666ff59083fee" style="position: relative; width: 100%; padding: 177.82426778242677% 0 0;">
-    <img id="thumb_6842141d891666ff59083fee" src="https://images.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/thumbnail.jpg" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; display: block;" alt="thumbnail" />
-    <div id="backdrop_6842141d891666ff59083fee" style="-webkit-backdrop-filter: blur(5px); backdrop-filter: blur(5px); position: absolute; top: 0; height: 100%; width: 100%;"></div>
+<div class="video-container">
+  <div class="video-wrapper">
+    <div id="vid_6842141d891666ff59083fee" style="position: relative; width: 100%; padding: 177.82426778242677% 0 0;">
+      <img id="thumb_6842141d891666ff59083fee" src="https://images.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/thumbnail.jpg" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; display: block;" alt="thumbnail" />
+      <div id="backdrop_6842141d891666ff59083fee" style="-webkit-backdrop-filter: blur(5px); backdrop-filter: blur(5px); position: absolute; top: 0; height: 100%; width: 100%;"></div>
+    </div>
+    <script type="text/javascript" id="scr_6842141d891666ff59083fee">
+      var s = document.createElement('script');
+      s.src = 'https://scripts.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/player.js';
+      s.async = true;
+      document.head.appendChild(s);
+    </script>
   </div>
-  <script type="text/javascript" id="scr_6842141d891666ff59083fee">
-    var s = document.createElement('script');
-    s.src = 'https://scripts.converteai.net/c9da0398-934e-4680-99b9-d4888d7094af/players/6842141d891666ff59083fee/player.js';
-    s.async = true;
-    document.head.appendChild(s);
-  </script>
+  <div class="sound-alert">
+    <img class="sound-icon" src="https://img.icons8.com/ios-filled/20/ffffff/speaker.png" alt="Som Ligado" />
+    <span>Por favor, certifique-se de que o som esteja ligado.</span>
+  </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 <body>
   <div id="header"></div>
   <main id="main"></main>
-  <div id="cta"></div>
   <div id="footer"></div>
   
 


### PR DESCRIPTION
## Summary
- wrap video in a `.video-container` and place sound alert under it
- keep CTA within `main` using script update
- remove extra placeholder `#cta` element
- apply responsive styles for the video container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843966e9d5c83279fbc167fb04df647