### PR TITLE
Fix vertical centering of page content

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -8,7 +8,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
 }
 
 main {


### PR DESCRIPTION
## Summary
- center all body elements vertically using `justify-content: center`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68439bcbdf1c83279c5cafdd66b6aee5